### PR TITLE
Add worktree lifecycle hooks for Claude Code desktop + tbd

### DIFF
--- a/.claude/hooks/worktree-create.mjs
+++ b/.claude/hooks/worktree-create.mjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+// Claude Code WorktreeCreate hook.
+//
+// IMPORTANT: this hook REPLACES git's default worktree creation. It must:
+//   1. create the worktree itself (git worktree add)
+//   2. print the worktree path to stdout (only the path — nothing else)
+//   3. exit 0 on success; any non-zero exit aborts worktree creation
+//
+// stdin receives JSON: { worktree_path, branch, cwd, session_id, ... }
+// where `cwd` is the source (main) repo.
+//
+// The actual setup work (copy env, pnpm install) is delegated to the shared
+// scripts in .worktree-hooks/lib/ so it stays identical to what tbd runs via
+// .worktree-hooks/preSession and .worktree-hooks/setup.
+
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+// Logs go to stderr so they never pollute the path we print on stdout.
+const log = (msg) => process.stderr.write(`[worktree-create] ${msg}\n`);
+
+let raw = '';
+process.stdin.setEncoding('utf8');
+for await (const chunk of process.stdin) raw += chunk;
+
+let data;
+try {
+  data = JSON.parse(raw);
+} catch (e) {
+  log(`could not parse hook input: ${e.message}`);
+  process.exit(2);
+}
+
+const worktree = data.worktree_path;
+const branch = data.branch;
+const source = data.cwd; // the main repo this worktree is created from
+
+if (!worktree || !branch || !source) {
+  log(`missing required fields (worktree_path/branch/cwd): ${raw}`);
+  process.exit(2);
+}
+
+const git = (args) =>
+  execFileSync('git', args, {
+    cwd: source,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+// 1. Create the worktree. Handle both "branch already exists" and "new branch".
+try {
+  let branchExists = true;
+  try {
+    git(['show-ref', '--verify', '--quiet', `refs/heads/${branch}`]);
+  } catch {
+    branchExists = false;
+  }
+
+  if (branchExists) {
+    git(['worktree', 'add', worktree, branch]);
+  } else {
+    git(['worktree', 'add', '-b', branch, worktree]);
+  }
+  log(`created worktree at ${worktree} on ${branch}`);
+} catch (e) {
+  log(`git worktree add failed: ${e.stderr || e.message}`);
+  process.exit(2); // aborts creation; stderr is shown to the user
+}
+
+// --- Best-effort setup via the shared .worktree-hooks/lib scripts. ---
+// Failures must NOT abort creation, so each runs in its own try/catch.
+const lib = join(source, '.worktree-hooks', 'lib');
+
+const runShared = (script, env, stdoutToStderr = false) => {
+  const path = join(lib, script);
+  if (!existsSync(path)) {
+    log(`shared script not found, skipping: ${path}`);
+    return;
+  }
+  try {
+    execFileSync('bash', [path], {
+      env: { ...process.env, ...env },
+      // Never let a shared script write to our stdout (reserved for the path).
+      stdio: ['ignore', stdoutToStderr ? 2 : 'inherit', 'inherit'],
+    });
+  } catch (e) {
+    log(`${script} failed (continuing): ${e.message}`);
+  }
+};
+
+// preSession-equivalent: env files + .vercel link. setup-equivalent: deps.
+runShared('copy-local-config.sh', { WT_PATH: worktree, WT_SRC: source }, true);
+runShared('install-deps.sh', { WT_PATH: worktree }, true);
+
+// 2. REQUIRED: print the worktree path on stdout so Claude Code knows where it is.
+process.stdout.write(`${worktree}\n`);

--- a/.claude/hooks/worktree-remove.mjs
+++ b/.claude/hooks/worktree-remove.mjs
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+// Claude Code WorktreeRemove hook.
+//
+// Fires when a worktree is removed (session exit or subagent finish).
+// This hook CANNOT block removal — it is for side effects only. Exit codes
+// and stderr are ignored. stdin receives JSON: { worktree_path, branch, ... }
+//
+// Delegates to the shared .worktree-hooks/lib/teardown.sh so the cleanup
+// logic is identical to what tbd runs via .worktree-hooks/archive.
+
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+const log = (msg) => process.stderr.write(`[worktree-remove] ${msg}\n`);
+
+let raw = '';
+process.stdin.setEncoding('utf8');
+for await (const chunk of process.stdin) raw += chunk;
+
+let data = {};
+try {
+  data = JSON.parse(raw);
+} catch {
+  // nothing we can do; removal proceeds regardless
+}
+
+const worktree = data.worktree_path;
+if (!worktree) process.exit(0);
+
+// Resolve the shared teardown script relative to the worktree's own checkout
+// (each worktree has its own copy of the tracked .worktree-hooks/ dir).
+const script = join(worktree, '.worktree-hooks', 'lib', 'teardown.sh');
+if (existsSync(script)) {
+  try {
+    execFileSync('bash', [script], {
+      env: { ...process.env, WT_PATH: worktree },
+      stdio: ['ignore', 'inherit', 'inherit'],
+    });
+  } catch (e) {
+    log(`teardown failed: ${e.message}`);
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "WorktreeCreate": [
+      {
+        "type": "command",
+        "command": "node \"${CLAUDE_PROJECT_DIR}/.claude/hooks/worktree-create.mjs\""
+      }
+    ],
+    "WorktreeRemove": [
+      {
+        "type": "command",
+        "command": "node \"${CLAUDE_PROJECT_DIR}/.claude/hooks/worktree-remove.mjs\""
+      }
+    ]
+  }
+}

--- a/.worktree-hooks/archive
+++ b/.worktree-hooks/archive
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# tbd archive hook (runs just before `git worktree remove`).
+# Delegates to the shared teardown lib (same logic the Claude Code
+# WorktreeRemove hook runs).
+set -euo pipefail
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+export WT_PATH="${TBD_WORKTREE_PATH:-$PWD}"
+
+bash "$DIR/lib/teardown.sh"

--- a/.worktree-hooks/lib/copy-local-config.sh
+++ b/.worktree-hooks/lib/copy-local-config.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Shared, tool-agnostic worktree setup: seed a new worktree with the
+# gitignored local config it can't get from git — env files and the Vercel
+# project linkage.
+#
+# Called by both:
+#   - tbd       -> .worktree-hooks/preSession  (blocking, before the agent)
+#   - Claude    -> .claude/hooks/worktree-create.mjs
+#
+# Inputs (environment):
+#   WT_PATH  absolute path to the worktree checkout   (required)
+#   WT_SRC   absolute path to the source/main repo    (required)
+set -uo pipefail
+
+: "${WT_PATH:?WT_PATH (worktree path) is required}"
+: "${WT_SRC:?WT_SRC (source repo path) is required}"
+
+# 1. Local env files.
+for f in .env .env.local .env.development.local; do
+  if [ -f "$WT_SRC/$f" ]; then
+    if cp "$WT_SRC/$f" "$WT_PATH/$f"; then
+      echo "[copy-local-config] copied $f"
+    else
+      echo "[copy-local-config] WARN: failed to copy $f" >&2
+    fi
+  fi
+done
+
+# 2. Vercel linkage (.vercel/project.json links the dir to the Vercel project;
+#    .env.preview.local holds pulled env). Skip output/ — it's build artifacts,
+#    not linkage, and can be large/stale. Guard against clobbering on re-run
+#    (tbd re-runs hooks when reviving an archived worktree).
+if [ -d "$WT_SRC/.vercel" ] && [ ! -e "$WT_PATH/.vercel/project.json" ]; then
+  if cp -R "$WT_SRC/.vercel" "$WT_PATH/.vercel"; then
+    rm -rf "$WT_PATH/.vercel/output"
+    echo "[copy-local-config] linked .vercel (excluding output/)"
+  else
+    echo "[copy-local-config] WARN: failed to copy .vercel" >&2
+  fi
+fi

--- a/.worktree-hooks/lib/install-deps.sh
+++ b/.worktree-hooks/lib/install-deps.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Shared, tool-agnostic worktree setup: install dependencies with pnpm.
+# node_modules is per-worktree (gitignored, not shared across checkouts).
+#
+# Called by both:
+#   - tbd       -> .worktree-hooks/setup  (parallel, alongside the agent)
+#   - Claude    -> .claude/hooks/worktree-create.mjs
+#
+# Inputs (environment):
+#   WT_PATH  absolute path to the worktree checkout   (required)
+set -uo pipefail
+
+: "${WT_PATH:?WT_PATH (worktree path) is required}"
+
+cd "$WT_PATH" || { echo "[install-deps] WARN: cannot cd to $WT_PATH" >&2; exit 1; }
+
+echo "[install-deps] pnpm install in $WT_PATH"
+pnpm install

--- a/.worktree-hooks/lib/teardown.sh
+++ b/.worktree-hooks/lib/teardown.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Shared, tool-agnostic worktree teardown: remove node_modules so that
+# `git worktree remove` doesn't trip over the untracked directory.
+#
+# Called by both:
+#   - tbd       -> .worktree-hooks/archive  (before `git worktree remove`)
+#   - Claude    -> .claude/hooks/worktree-remove.mjs
+#
+# Inputs (environment):
+#   WT_PATH  absolute path to the worktree checkout   (required)
+set -uo pipefail
+
+: "${WT_PATH:?WT_PATH (worktree path) is required}"
+
+if [ -d "$WT_PATH/node_modules" ]; then
+  if rm -rf "$WT_PATH/node_modules"; then
+    echo "[teardown] removed node_modules in $WT_PATH"
+  else
+    echo "[teardown] WARN: failed to remove node_modules" >&2
+  fi
+fi

--- a/.worktree-hooks/preSession
+++ b/.worktree-hooks/preSession
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# tbd preSession hook (BLOCKING — the agent does not start until this exits).
+# Use for anything the agent must have on its first turn: env files, config.
+#
+# tbd runs this with cwd = worktree path and TBD_* env vars set. We translate
+# those to the generic WT_* contract and delegate to the shared lib script,
+# so the real logic stays in one place shared with the Claude Code hook.
+set -euo pipefail
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+export WT_PATH="${TBD_WORKTREE_PATH:-$PWD}"
+export WT_SRC="${TBD_REPO_PATH:?TBD_REPO_PATH not set by tbd}"
+
+bash "$DIR/lib/copy-local-config.sh"

--- a/.worktree-hooks/setup
+++ b/.worktree-hooks/setup
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# tbd setup hook (PARALLEL — runs in its own terminal while the agent is
+# already running). Use for slow work the agent doesn't need immediately:
+# pnpm install, warming caches.
+#
+# Delegates to the shared lib script (same logic the Claude Code hook runs).
+set -euo pipefail
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+export WT_PATH="${TBD_WORKTREE_PATH:-$PWD}"
+
+bash "$DIR/lib/install-deps.sh"


### PR DESCRIPTION
Sets up automatic worktree setup/teardown that works with **both** worktree tools used on this repo — [tbd](https://github.com/cheapsteak/tbd) and Claude Code desktop — without duplicating logic.

## How it works

The real work lives in `.worktree-hooks/lib/*.sh` (one source of truth). Thin per-tool adapters translate each tool's inputs and call those shared scripts:

| Tool | Entry point | Mechanism |
| --- | --- | --- |
| **tbd** | `.worktree-hooks/{preSession,setup,archive}` | tbd's canonical `.worktree-hooks/<event>` location (executable files, run via `/bin/bash`, `cwd`=worktree, `TBD_*` env) |
| **Claude Code** | `.claude/settings.json` → `.claude/hooks/worktree-{create,remove}.mjs` | `WorktreeCreate`/`WorktreeRemove` hooks |

Both converge on the same `lib/` scripts, so setup behavior stays identical across tools — edit the lib once, both pick it up.

> Note: Claude Code's `WorktreeCreate` *replaces* git's worktree creation, so `worktree-create.mjs` runs `git worktree add` itself and prints the path. tbd creates the worktree itself and only runs setup. That irreducible difference is the only per-tool code; all actual setup is shared.

## Shared lib scripts

- **`copy-local-config.sh`** — seeds gitignored local config a fresh worktree can't get from git: `.env*` files + the `.vercel` linkage (`project.json` + `.env.preview.local`), excluding `.vercel/output/` build artifacts.
- **`install-deps.sh`** — `pnpm install` (matches the project's package manager after #8).
- **`teardown.sh`** — removes `node_modules` before worktree removal.

tbd's blocking/parallel split is honored: env/config copy runs in the blocking `preSession` hook (the agent waits for it); `pnpm install` runs in the parallel `setup` hook.

## Testing

Exercised both front-ends end-to-end against throwaway repos (with a realistic gitignore): worktree creation, `.env` + `.vercel` seeding (`output/` excluded), `pnpm install`, and `node_modules` teardown all verified. Hook entry points are committed with the executable bit (`100755`) that tbd requires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)